### PR TITLE
Allow where args to be nil

### DIFF
--- a/src/suricatta/dsl.clj
+++ b/src/suricatta/dsl.clj
@@ -290,6 +290,9 @@
   (-val [v] (DSL/val v)))
 
 (extend-protocol IDeferred
+  nil
+  (-unwrap [v] v)
+
   Object
   (-unwrap [self]
     (impl/wrap-if-need self))

--- a/test/suricatta/dsl_test.clj
+++ b/test/suricatta/dsl_test.clj
@@ -91,6 +91,13 @@
       (is (= (fmt/get-sql q)
              "select 1 \"one\" from book where ((book.age > ?) and (book.in_store is ?))"))))
 
+  (testing "Where with nil argument"
+    (let [q (-> (dsl/select "name")
+                (dsl/from "book")
+                (dsl/where ["author_id = coalesce(?, 123)" nil]))]
+      (is (= (fmt/get-sql q)
+             "select name from book where (author_id = coalesce(?, 123))"))))
+
   (testing "Select clause with group by"
     (let [q (-> (dsl/select (dsl/field "authorid")
                             (dsl/field "count(*)"))


### PR DESCRIPTION
```
> (-> (dsl/select :name)
                  (dsl/from :book)
                  (dsl/where ["author_id = coalesce(?, 123)" nil])
                  (fmt/get-sql))

IllegalArgumentException No implementation of method: :-unwrap of protocol: #'suricatta.dsl/IDeferred found for class: nil  clojure.core/-cache-protocol-fn (core_deftype.clj:554)
```

I believe the query is valid and should result in: 
```sql
select name from book where (author_id = coalesce(?, 123))
```