### PR TITLE
Skip nil values in insert-values

### DIFF
--- a/src/suricatta/dsl.clj
+++ b/src/suricatta/dsl.clj
@@ -623,7 +623,9 @@
   [t values]
   (defer
     (-> (fn [acc [k v]]
-          (.set acc (-field k) (-unwrap v)))
+          (if (nil? v)
+            acc
+            (.set acc (-field k) (-unwrap v))))
         (reduce (-unwrap t) values)
         (.newRecord))))
 

--- a/test/suricatta/dsl_test.clj
+++ b/test/suricatta/dsl_test.clj
@@ -261,6 +261,11 @@
                 (dsl/insert-values {:f1 2 :f2 4}))]
       (is (= (fmt/get-sql q {:dialect :pgsql})
              "insert into t1 (f1, f2) values (?, ?), (?, ?)"))))
+  (testing "Insert statement with nil values"
+    (let [q (-> (dsl/insert-into :t1)
+                (dsl/insert-values {:f1 1 :f2 nil :f3 2}))]
+      (is (= (fmt/get-sql q {:dialect :pgsql})
+             "insert into t1 (f1, f3) values (?, ?)"))))
   (testing "Insert statement from values as maps with returning"
     (let [q (-> (dsl/insert-into :t1)
                 (dsl/insert-values {:f1 1 :f2 3})


### PR DESCRIPTION
Otherwise NPE will be thrown:
```
java.lang.NullPointerException: null
 at org.jooq.impl.InsertImpl.set (InsertImpl.java:616)
    org.jooq.impl.InsertImpl.set (InsertImpl.java:91)
    sun.reflect.NativeMethodAccessorImpl.invoke0 (NativeMethodAccessorImpl.java:-2)
    sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    java.lang.reflect.Method.invoke (Method.java:497)
    clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:93)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:28)
    suricatta.dsl$insert_values$func__578__auto____1327$fn__1329.invoke (dsl.clj:628)
    clojure.core.protocols$fn__6755.invokeStatic (protocols.clj:167)
    clojure.core.protocols/fn (protocols.clj:124)
    clojure.core.protocols$fn__6710$G__6705__6719.invoke (protocols.clj:19)
    clojure.core.protocols$seq_reduce.invokeStatic (protocols.clj:31)
    clojure.core.protocols$fn__6738.invokeStatic (protocols.clj:75)
    clojure.core.protocols/fn (protocols.clj:75)
    clojure.core.protocols$fn__6684$G__6679__6697.invoke (protocols.clj:13)
    clojure.core$reduce.invokeStatic (core.clj:6545)
    suricatta.dsl$insert_values$func__578__auto____1327.invoke (dsl.clj:629)
```