### PR TITLE
Fixes null values being cast to varchar

### DIFF
--- a/src/suricatta/dsl.clj
+++ b/src/suricatta/dsl.clj
@@ -648,7 +648,9 @@
        (reduce-kv (fn [acc k v]
                  (let [k (-unwrap k)
                        v (-unwrap v)]
-                   (.set acc (-field k) v)))
+                   (if (nil? v)
+                     acc
+                     (.set acc (-field k) v))))
                   t kv))))
   ([t k v]
    (defer


### PR DESCRIPTION
Null values were always cast to a varchar. This issue appeared to be solved for `insert` statements, I used the same technique to patch the `set` statement.